### PR TITLE
Configurable opacity and mouse buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,18 +37,24 @@ sky = SkyRocket:new({
   -- Which modifiers to hold to move a window?
   moveModifiers = {'cmd', 'shift'},
 
+  -- Which mouse button to hold to move a window?
+  moveMouseButton = 'left',
+
   -- Which modifiers to hold to resize a window?
   resizeModifiers = {'ctrl', 'shift'},
+
+  -- Which mouse button to hold to resize a window?
+  resizeMouseButton = 'left',
 })
 ```
 
 ### Moving
 
-To move a window, hold your `moveModifiers` down, then click and drag a window.
+To move a window, hold your `moveModifiers` down, then click `moveMouseButton` and drag a window.
 
 ### Resizing
 
-To resize a window, hold your `resizeModifiers` down, then click and drag a window.
+To resize a window, hold your `resizeModifiers` down, then click `resizeMouseButton` and drag a window.
 
 ### Disabling move/resize for apps
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Once you've installed it, add this to your `~/.hammerspoon/init.lua` file:
 local SkyRocket = hs.loadSpoon("SkyRocket")
 
 sky = SkyRocket:new({
+  -- Opacity of resize canvas
+  opacity = 0.3,
+
   -- Which modifiers to hold to move a window?
   moveModifiers = {'cmd', 'shift'},
 

--- a/init.lua
+++ b/init.lua
@@ -27,7 +27,7 @@ local function tableToMap(table)
   return map
 end
 
-local function createResizeCanvas()
+local function createResizeCanvas(alpha)
   local canvas = hs.canvas.new{}
 
   canvas:insertElement(
@@ -35,7 +35,7 @@ local function createResizeCanvas()
       id = 'opaque_layer',
       action = 'fill',
       type = 'rectangle',
-      fillColor = { red = 0, green = 0, blue = 0, alpha = 0.3 },
+      fillColor = { red = 0, green = 0, blue = 0, alpha = alpha },
       roundedRectRadii = { xRadius = 5.0, yRadius = 5.0 },
     },
     1
@@ -59,6 +59,7 @@ end
 
 -- Usage:
 --   resizer = SkyRocket:new({
+--     opacity = 0.3,
 --     moveModifiers = {'cmd', 'shift'},
 --     resizeModifiers = {'ctrl', 'shift'}
 --   })
@@ -71,7 +72,7 @@ function SkyRocket:new(options)
     dragging = false,
     dragType = nil,
     moveModifiers = options.moveModifiers or {'cmd', 'shift'},
-    windowCanvas = createResizeCanvas(),
+    windowCanvas = createResizeCanvas(options.opacity or 0.3),
     resizeModifiers = options.resizeModifiers or {'ctrl', 'shift'},
     targetWindow = nil,
   }

--- a/init.lua
+++ b/init.lua
@@ -61,9 +61,21 @@ end
 --   resizer = SkyRocket:new({
 --     opacity = 0.3,
 --     moveModifiers = {'cmd', 'shift'},
+--     moveMouseButton = 'left',
 --     resizeModifiers = {'ctrl', 'shift'}
+--     resizeMouseButton = 'left',
 --   })
 --
+local function buttonNameToEventType(name, optionName)
+  if name == 'left' then
+    return hs.eventtap.event.types.leftMouseDown
+  end
+  if name == 'right' then
+    return hs.eventtap.event.types.rightMouseDown
+  end
+  error(optionName .. ': only "left" and "right" mouse button supported, got ' .. name)
+end
+
 function SkyRocket:new(options)
   options = options or {}
 
@@ -71,8 +83,10 @@ function SkyRocket:new(options)
     disabledApps = tableToMap(options.disabledApps or {}),
     dragging = false,
     dragType = nil,
+    moveStartMouseEvent = buttonNameToEventType(options.moveMouseButton or 'left', 'moveMouseButton'),
     moveModifiers = options.moveModifiers or {'cmd', 'shift'},
     windowCanvas = createResizeCanvas(options.opacity or 0.3),
+    resizeStartMouseEvent = buttonNameToEventType(options.resizeMouseButton or 'left', 'resizeMouseButton'),
     resizeModifiers = options.resizeModifiers or {'ctrl', 'shift'},
     targetWindow = nil,
   }
@@ -81,17 +95,26 @@ function SkyRocket:new(options)
   self.__index = self
 
   resizer.clickHandler = hs.eventtap.new(
-    { hs.eventtap.event.types.leftMouseDown },
+    {
+      hs.eventtap.event.types.leftMouseDown,
+      hs.eventtap.event.types.rightMouseDown,
+    },
     resizer:handleClick()
   )
 
   resizer.cancelHandler = hs.eventtap.new(
-    { hs.eventtap.event.types.leftMouseUp },
+    {
+      hs.eventtap.event.types.leftMouseUp,
+      hs.eventtap.event.types.rightMouseUp,
+    },
     resizer:handleCancel()
   )
 
   resizer.dragHandler = hs.eventtap.new(
-    { hs.eventtap.event.types.leftMouseDragged },
+    {
+      hs.eventtap.event.types.leftMouseDragged,
+      hs.eventtap.event.types.rightMouseDragged,
+    },
     resizer:handleDrag()
   )
 
@@ -201,9 +224,10 @@ function SkyRocket:handleClick()
     if self.dragging then return true end
 
     local flags = event:getFlags()
+    local eventType = event:getType()
 
-    local isMoving = flags:containExactly(self.moveModifiers)
-    local isResizing = flags:containExactly(self.resizeModifiers)
+    local isMoving = eventType == self.moveStartMouseEvent and flags:containExactly(self.moveModifiers)
+    local isResizing = eventType == self.resizeStartMouseEvent and flags:containExactly(self.resizeModifiers)
 
     if isMoving or isResizing then
       local currentWindow = getWindowUnderMouse()


### PR DESCRIPTION
I've made two changes:
1) configurable opacity for resize canvas, I prefer 0.75 in my configs
2) configurable mouse button for move/resize events - now it's possible to configure this spoon like https://awesomewm.org/
```
sky = SkyRocket:new({
  opacity = 0.75,
  moveModifiers = {'cmd'},
  moveMouseButton = 'left',
  resizeModifiers = {'cmd'},
  resizeMouseButton = 'right',
})
```