### PR TITLE
Update init.lua to handle screens stretch across multiple monitors

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -50,10 +50,9 @@ local function getWindowUnderMouse()
   local _ = hs.application
 
   local my_pos = hs.geometry.new(hs.mouse.absolutePosition())
-  local my_screen = hs.mouse.getCurrentScreen()
 
   return hs.fnutils.find(hs.window.orderedWindows(), function(w)
-    return my_screen == w:screen() and my_pos:inside(w:frame())
+    return my_pos:inside(w:frame())
   end)
 end
 


### PR DESCRIPTION
Closes #8.

I've found that SkyRocket's support for windows streched across multiple monitors is not great.
From the `init.lua` file, I see that there's a comparison between `hs.mouse.getCurrentScreen()` and `w:screen()`. This is the source of the problem.

If I have a window that's stretched across multiple screens, and if (for example) `w:screen()` returns `screen_1` but I'm trying to click on the part of the window that's stretched onto `screen_2`, then there will be a mismatch between the value of `hs.mouse.getCurrentScreen()` and `w:screen()`. I'd recommend removing this comparison.