### PR TITLE
Enable focusing of clicked window

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ sky = SkyRocket:new({
   resizeMouseButton = 'left',
 
   -- Should the current window be focused & brought to the front when you click on it?
-  enableSelection = false,
+  focusWindowOnClick = false,
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ sky = SkyRocket:new({
 
   -- Which mouse button to hold to resize a window?
   resizeMouseButton = 'left',
+
+  -- Should the current window be focused & brought to the front when you click on it?
+  enableSelection = false,
 })
 ```
 

--- a/init.lua
+++ b/init.lua
@@ -64,7 +64,7 @@ end
 --     moveMouseButton = 'left',
 --     resizeModifiers = {'ctrl', 'shift'}
 --     resizeMouseButton = 'left',
---     enableSelection = false,
+--     focusWindowOnClick = false,
 --   })
 --
 local function buttonNameToEventType(name, optionName)
@@ -90,7 +90,7 @@ function SkyRocket:new(options)
     resizeStartMouseEvent = buttonNameToEventType(options.resizeMouseButton or 'left', 'resizeMouseButton'),
     resizeModifiers = options.resizeModifiers or {'ctrl', 'shift'},
     targetWindow = nil,
-    enableSelection = options.enableSelection or false,
+    focusWindowOnClick = options.focusWindowOnClick or false,
   }
 
   setmetatable(resizer, self)
@@ -254,7 +254,7 @@ function SkyRocket:handleClick()
       self.dragHandler:start()
       self.clickHandler:stop()
 
-      if enableSelection then
+      if focusWindowOnClick then
         currentWindow:focus()
       end
       return true

--- a/init.lua
+++ b/init.lua
@@ -64,6 +64,7 @@ end
 --     moveMouseButton = 'left',
 --     resizeModifiers = {'ctrl', 'shift'}
 --     resizeMouseButton = 'left',
+--     enableSelection = false,
 --   })
 --
 local function buttonNameToEventType(name, optionName)
@@ -89,6 +90,7 @@ function SkyRocket:new(options)
     resizeStartMouseEvent = buttonNameToEventType(options.resizeMouseButton or 'left', 'resizeMouseButton'),
     resizeModifiers = options.resizeModifiers or {'ctrl', 'shift'},
     targetWindow = nil,
+    enableSelection = options.enableSelection or false,
   }
 
   setmetatable(resizer, self)
@@ -252,7 +254,9 @@ function SkyRocket:handleClick()
       self.dragHandler:start()
       self.clickHandler:stop()
 
-      -- Prevent selection
+      if enableSelection then
+        currentWindow:focus()
+      end
       return true
     else
       return nil


### PR DESCRIPTION
Closes #10

When I click on a window (to move it or to resize it), I'd like that window to be focused (rather than remaining unfocused). I propose adding an option to SkyRocket that enables this.


https://github.com/user-attachments/assets/aea35da0-e8fb-471e-8359-50ee4f1633a0

