### PR TITLE
add fillColor, strokeColor, and strokeWidth config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ sky = SkyRocket:new({
   -- Opacity of resize canvas
   opacity = 0.3,
 
+  -- Change default color of resize canvas (if provided, overwrites `opacity`)
+  fillColor = { white = 0.5, alpha = 0.3 }, -- as per `hs.drawing.color`
+
+  -- Change default color of resize canvas outline
+  strokeColor = { white = 0.5, alpha = 0.3 }, -- as per `hs.drawing.color`
+
+  -- Change default width of resize canvas outline
+  strokeWidth = 1, -- set `strokeWidth = 0` to hide the outline
+
   -- Which modifiers to hold to move a window?
   moveModifiers = {'cmd', 'shift'},
 

--- a/init.lua
+++ b/init.lua
@@ -27,16 +27,18 @@ local function tableToMap(table)
   return map
 end
 
-local function createResizeCanvas(alpha)
+local function createResizeCanvas(customFill, customStroke, customStrokeWidth)
   local canvas = hs.canvas.new{}
 
   canvas:insertElement(
     {
       id = 'opaque_layer',
-      action = 'fill',
+      action = 'strokeAndFill',
       type = 'rectangle',
-      fillColor = { red = 0, green = 0, blue = 0, alpha = alpha },
-      roundedRectRadii = { xRadius = 5.0, yRadius = 5.0 },
+      fillColor = customFill,
+      strokeColor = customStroke,
+      strokeWidth = customStrokeWidth,
+      roundedRectRadii = { xRadius = 10.0 + customStrokeWidth, yRadius = 10.0 + customStrokeWidth },
     },
     1
   )
@@ -60,6 +62,9 @@ end
 -- Usage:
 --   resizer = SkyRocket:new({
 --     opacity = 0.3,
+--     fillColor = { white = 0.5, alpha = 0.3 }, -- as per `hs.drawing.color` (if provided, overwrites `opacity`)
+--     strokeColor = { white = 0.5, alpha = 0.3 }, -- also as per `hs.drawing.color`
+--     strokeWidth = 1,
 --     moveModifiers = {'cmd', 'shift'},
 --     moveMouseButton = 'left',
 --     resizeModifiers = {'ctrl', 'shift'}
@@ -80,13 +85,29 @@ end
 function SkyRocket:new(options)
   options = options or {}
 
+  local fill = nil
+  if type(options.fillColor) == "table" then
+    fill = options.fillColor
+  else
+    fill = { white = 0, alpha = options.opacity or 0.3 }
+  end
+
+  local stroke = nil
+  if type(options.fillColor) == "table" then
+    stroke = options.strokeColor
+  else
+    stroke = { white = 0, alpha = options.opacity or 0.3 }
+  end
+
+  local strokeWidth = options.strokeWidth or 1
+
   local resizer = {
     disabledApps = tableToMap(options.disabledApps or {}),
     dragging = false,
     dragType = nil,
     moveStartMouseEvent = buttonNameToEventType(options.moveMouseButton or 'left', 'moveMouseButton'),
     moveModifiers = options.moveModifiers or {'cmd', 'shift'},
-    windowCanvas = createResizeCanvas(options.opacity or 0.3),
+    windowCanvas = createResizeCanvas(fill, stroke, strokeWidth),
     resizeStartMouseEvent = buttonNameToEventType(options.resizeMouseButton or 'left', 'resizeMouseButton'),
     resizeModifiers = options.resizeModifiers or {'ctrl', 'shift'},
     targetWindow = nil,


### PR DESCRIPTION
Allow custom fill color and stroke color/width.

Additionally, some minor enhancements:
- Make the default color(s) a mid-gray that is visible on both light and dark backgrounds.
- Adjust the corner radius to match the native window style.